### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv-python
-numpy
+numpy==1.19.3
 python3_xlib
 pyautogui
 mss


### PR DESCRIPTION
specify a slightly older, but still sufficient, version of numpy to avoid problems with Windows being unable to install the latest version:

ImportError: numpy.core.multiarray failed to import