### PR TITLE
Fix retina check by making grep case insensitive

### DIFF
--- a/python_imagesearch/imagesearch.py
+++ b/python_imagesearch/imagesearch.py
@@ -10,7 +10,7 @@ import mss
 
 is_retina = False
 if platform.system() == "Darwin":
-    is_retina = subprocess.call("system_profiler SPDisplaysDataType | grep 'retina'", shell=True) == 0
+    is_retina = subprocess.call("system_profiler SPDisplaysDataType | grep -i 'retina'", shell=True) == 0
 
 '''
 


### PR DESCRIPTION
The `imagesearcharea` function wasn't working properly when used between a retina vs. non-retina external display on MacOS. After some basic debugging, it was due to the thumbnail not being scaled properly on the retina display.

The issue is due to the `is_retina` variable being determined via a case sensitive grep on `system_profiler SPDisplaysDataType`. The `retina` keyword is capitalized causing the grep to give a false negative:

```
system_profiler SPDisplaysDataType
Graphics/Displays:

    Apple M1 Max:

      Chipset Model: Apple M1 Max
      Type: GPU
      Bus: Built-In
      Total Number of Cores: 32
      Vendor: Apple (0x106b)
      Metal Family: Supported, Metal GPUFamily Apple 7
      Displays:
        Studio Display:
          Display Type: Retina LCD
          Resolution: 5120 x 2880 Retina
          Display Serial Number: ...
          Display Firmware Version: ...
          Main Display: Yes
          Mirror: Off
          Online: Yes
          Automatically Adjust Brightness: Yes
```

The fix is to make the grep case insensitive.

---

Fix verified in python REPL:

Previous wrong output:

```
>>> subprocess.call("system_profiler SPDisplaysDataType | grep 'retina'", shell=True) == 0
False
```

Correct output with fix:

```
>>> subprocess.call("system_profiler SPDisplaysDataType | grep -i 'retina'", shell=True) == 0
          Display Type: Retina LCD
          Resolution: 5120 x 2880 Retina
True
```